### PR TITLE
many changes, much cleanup

### DIFF
--- a/MEOColorPhasing.cpp
+++ b/MEOColorPhasing.cpp
@@ -13,7 +13,9 @@
 
 #include <MEOColorPhasing.h>
 
+#ifndef PI
 #define PI 3.14159265
+#endif
 
 MEOColorPhasing::MEOColorPhasing(MEOG35& g35, uint8_t pattern) : MEOLightProgram(g35, pattern), wait_(0), frequencyR_(0.06), frequencyG_(0.06), frequencyB_(0.06),
     phaseR_(0), phaseG_(2*PI/3), phaseB_(4*PI/3), center_(8), width_(7), fStep_(0), pStep_(0), fForward_(true), turn_(0), pattern_(pattern), grnOff_(false), bluOff_(false), redOff_(false)
@@ -80,7 +82,7 @@ uint32_t MEOColorPhasing::Do()
         frequencyB_ = float(fStep_) / 100.0;
 		redOff_ = false; grnOff_ = false; bluOff_ = false;
         break;
-    case 6: //Red twinkle 
+    case 6: //Red twinkle
         phaseR_ = 0;
         phaseG_ = pStep_;
         phaseB_ = pStep_;
@@ -89,7 +91,7 @@ uint32_t MEOColorPhasing::Do()
         frequencyB_ = float(fStep_) / 100.0;
 		redOff_ = false; grnOff_ = false; bluOff_ = false;
         break;
-    case 7: //Green twinkle 
+    case 7: //Green twinkle
         phaseR_ = pStep_;
         phaseG_ = 0;
         phaseB_ = pStep_;

--- a/MEOG35.cpp
+++ b/MEOG35.cpp
@@ -17,7 +17,7 @@ MEOG35::MEOG35() : light_count_(0)
 {
 }
 
-bool MEOG35::set_color_if_in_range(uint8_t position, uint8_t intensity,
+bool MEOG35::set_color_if_in_range(uint16_t position, uint8_t intensity,
                                    color_t color)
 {
     if (position >= light_count_)
@@ -61,7 +61,7 @@ color_t MEOG35::color_hue(uint8_t h)
     }
 }
 
-void MEOG35::fill_color(uint8_t begin, uint8_t count,
+void MEOG35::fill_color(uint16_t begin, uint16_t count,
                         uint8_t intensity, color_t color)
 {
     while (count--)
@@ -70,7 +70,7 @@ void MEOG35::fill_color(uint8_t begin, uint8_t count,
     }
 }
 
-void MEOG35::fill_random_max(uint8_t begin, uint8_t count, uint8_t intensity)
+void MEOG35::fill_random_max(uint16_t begin, uint16_t count, uint8_t intensity)
 {
     while (count--)
     {
@@ -78,8 +78,8 @@ void MEOG35::fill_random_max(uint8_t begin, uint8_t count, uint8_t intensity)
     }
 }
 
-void MEOG35::fill_sequence(uint8_t begin, uint8_t count,
-                           uint16_t sequence, uint8_t span_size,
+void MEOG35::fill_sequence(uint16_t begin, uint16_t count,
+                           uint16_t sequence, uint16_t span_size,
                            uint8_t intensity,
                            color_t (*sequence_func)(uint16_t sequence))
 {
@@ -89,15 +89,15 @@ void MEOG35::fill_sequence(uint8_t begin, uint8_t count,
     }
 }
 
-void MEOG35::fill_sequence(uint16_t sequence, uint8_t span_size,
+void MEOG35::fill_sequence(uint16_t sequence, uint16_t span_size,
                            uint8_t intensity,
                            color_t (*sequence_func)(uint16_t sequence))
 {
     fill_sequence(0, light_count_, sequence, span_size, intensity, sequence_func);
 }
 
-void MEOG35::fill_sequence(uint8_t begin, uint8_t count,
-                           uint16_t sequence, uint8_t span_size,
+void MEOG35::fill_sequence(uint16_t begin, uint16_t count,
+                           uint16_t sequence, uint16_t span_size,
                            bool (*sequence_func)(uint16_t sequence, color_t& color,
                                    uint8_t& intensity))
 {
@@ -160,9 +160,4 @@ color_t MEOG35::max_color(uint16_t color)
     default:
         return COLOR_WHITE;
     }
-}
-
-void MEOG35::broadcast_intensity(uint8_t intensity)
-{
-    set_color(get_broadcast_bulb(), intensity, COLOR_BLACK);
 }

--- a/MEOG35.h
+++ b/MEOG35.h
@@ -83,10 +83,10 @@ public:
     }
 
     // Turn on a specific LED with a color and brightness
-    virtual void set_color(uint8_t bulb, uint8_t intensity, color_t color) = 0;
+    virtual void set_color(uint16_t bulb, uint8_t intensity, color_t color) = 0;
 
     // Like set_color, but doesn't explode with positions out of range
-    virtual bool set_color_if_in_range(uint8_t led, uint8_t intensity,
+    virtual bool set_color_if_in_range(uint16_t led, uint8_t intensity,
                                        color_t color);
 
     // Color data type
@@ -102,27 +102,25 @@ public:
     static color_t max_color(uint16_t color);
 
     // Make all LEDs the same color starting at specified beginning LED
-    virtual void fill_color(uint8_t begin, uint8_t count, uint8_t intensity,
+    virtual void fill_color(uint16_t begin, uint16_t count, uint8_t intensity,
                             color_t color);
-    virtual void fill_random_max(uint8_t begin, uint8_t count, uint8_t intensity);
+    virtual void fill_random_max(uint16_t begin, uint16_t count, uint8_t intensity);
 
-    virtual void fill_sequence(uint16_t sequence, uint8_t span_size,
+    virtual void fill_sequence(uint16_t sequence, uint16_t span_size,
                                uint8_t intensity,
                                color_t (*sequence_func)(uint16_t sequence));
-    virtual void fill_sequence(uint8_t begin, uint8_t count, uint16_t sequence,
-                               uint8_t span_size, uint8_t intensity,
+    virtual void fill_sequence(uint16_t begin, uint16_t count, uint16_t sequence,
+                               uint16_t span_size, uint8_t intensity,
                                color_t (*sequence_func)(uint16_t sequence));
-    virtual void fill_sequence(uint8_t begin, uint8_t count, uint16_t sequence,
-                               uint8_t span_size,
+    virtual void fill_sequence(uint16_t begin, uint16_t count, uint16_t sequence,
+                               uint16_t span_size,
                                bool (*sequence_func)(uint16_t sequence,
                                        color_t& color,
                                        uint8_t& intensity));
-    virtual void broadcast_intensity(uint8_t intensity);
+    virtual void broadcast_intensity(uint8_t intensity) = 0;
 
 protected:
     uint16_t light_count_;
-
-    virtual uint8_t get_broadcast_bulb() = 0;
 };
 
 #endif  // INCLUDE_MEOG35_ARDUINO_H

--- a/MEOG35String.cpp
+++ b/MEOG35String.cpp
@@ -42,17 +42,12 @@ MEOG35String::MEOG35String(uint8_t pin, uint8_t light_count,
 {
     pinMode(pin, OUTPUT);
     light_count_ = light_count;
+    if (physical_light_count_ == 0)
+        physical_light_count_ = light_count;
 }
+#define SET_OR_CLEAR(v, b) { if (v & b) { ONE(pin_); } else { ZERO(pin_); } }
 
-MEOG35String::MEOG35String(uint8_t pin, uint8_t light_count)
-    : MEOG35(), pin_(pin), physical_light_count_(light_count),
-      bulb_zero_(0), is_forward_(true)
-{
-    pinMode(pin, OUTPUT);
-    light_count_ = light_count;
-}
-
-void MEOG35String::set_color(uint8_t bulb, uint8_t intensity, color_t color)
+void MEOG35String::set_color(uint16_t bulb, uint8_t intensity, color_t color)
 {
     bulb += bulb_zero_;
     uint8_t r, g, b;
@@ -61,9 +56,7 @@ void MEOG35String::set_color(uint8_t bulb, uint8_t intensity, color_t color)
     b = (color >> 8) & 0x0F;
 
     if (intensity > MAX_INTENSITY)
-    {
         intensity = MAX_INTENSITY;
-    }
 
     noInterrupts();
 
@@ -71,222 +64,40 @@ void MEOG35String::set_color(uint8_t bulb, uint8_t intensity, color_t color)
     delayMicroseconds(DELAYSHORT);
 
     // LED Address
-    if (bulb & 0x20)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (bulb & 0x10)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (bulb & 0x08)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (bulb & 0x04)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (bulb & 0x02)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (bulb & 0x01)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
+    SET_OR_CLEAR(bulb, 0x20);
+    SET_OR_CLEAR(bulb, 0x10);
+    SET_OR_CLEAR(bulb, 0x08);
+    SET_OR_CLEAR(bulb, 0x04);
+    SET_OR_CLEAR(bulb, 0x02);
+    SET_OR_CLEAR(bulb, 0x01);
 
     // Brightness
-    if (intensity & 0x80)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (intensity & 0x40)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (intensity & 0x20)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (intensity & 0x10)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (intensity & 0x08)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (intensity & 0x04)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (intensity & 0x02)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (intensity & 0x01)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
+    SET_OR_CLEAR(intensity, 0x80);
+    SET_OR_CLEAR(intensity, 0x40);
+    SET_OR_CLEAR(intensity, 0x20);
+    SET_OR_CLEAR(intensity, 0x10);
+    SET_OR_CLEAR(intensity, 0x08);
+    SET_OR_CLEAR(intensity, 0x04);
+    SET_OR_CLEAR(intensity, 0x02);
+    SET_OR_CLEAR(intensity, 0x01);
 
     // Blue
-    if (b & 0x8)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (b & 0x4)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (b & 0x2)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (b & 0x1)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
+    SET_OR_CLEAR(b, 0x08);
+    SET_OR_CLEAR(b, 0x04);
+    SET_OR_CLEAR(b, 0x02);
+    SET_OR_CLEAR(b, 0x01);
 
     // Green
-    if (g & 0x8)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (g & 0x4)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (g & 0x2)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (g & 0x1)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
+    SET_OR_CLEAR(g, 0x08);
+    SET_OR_CLEAR(g, 0x04);
+    SET_OR_CLEAR(g, 0x02);
+    SET_OR_CLEAR(g, 0x01);
 
     // Red
-    if (r & 0x8)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (r & 0x4)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (r & 0x2)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
-    if (r & 0x1)
-    {
-        ONE(pin_);
-    }
-    else
-    {
-        ZERO(pin_);
-    }
+    SET_OR_CLEAR(r, 0x08);
+    SET_OR_CLEAR(r, 0x04);
+    SET_OR_CLEAR(r, 0x02);
+    SET_OR_CLEAR(r, 0x01);
 
     digitalWrite(pin_, LOW);
     delayMicroseconds(DELAYEND);

--- a/MEOG35String.h
+++ b/MEOG35String.h
@@ -30,16 +30,15 @@ public:
     // |physical_light_count|: the number of physical bulbs on the string.
     // |bulb_zero|: the index of the first bulb (almost always zero).
     // |is_forward|: true if the closest bulb to the plug has the lowest index.
-    MEOG35String(uint8_t pin, uint8_t light_count, uint8_t physical_light_count,
-                 uint8_t bulb_zero, bool is_forward);
-    MEOG35String(uint8_t pin, uint8_t light_count);
+    MEOG35String(uint8_t pin, uint8_t light_count, uint8_t physical_light_count = 0,
+                 uint8_t bulb_zero = 0, bool is_forward = true);
 
     // Implementation of G35 interface.
-    virtual uint16_t get_light_count()
+    virtual uint16_t get_light_count() override
     {
         return light_count_;
     }
-    void set_color(uint8_t led, uint8_t intensity, color_t color);
+    void set_color(uint16_t led, uint8_t intensity, color_t color);
 
     // Initialize lights by giving them each an address.
     void enumerate();
@@ -48,8 +47,14 @@ public:
     // debugging.
     void do_test_patterns();
 
+    virtual void broadcast_intensity(uint8_t intensity) override
+    {
+        set_color(get_broadcast_bulb(), intensity, COLOR_BLACK);
+    }
+
+
 protected:
-    virtual uint8_t get_broadcast_bulb()
+    uint16_t get_broadcast_bulb()
     {
         return BROADCAST_BULB;
     }

--- a/MEOG35StringGroup.cpp
+++ b/MEOG35StringGroup.cpp
@@ -19,11 +19,11 @@ void MEOG35StringGroup::AddString(MEOG35* g35)
     if (string_count_ == MAX_STRINGS)
         return;
 
-    uint16_t light_count = g35->get_light_count();
-    string_offsets_[string_count_] = light_count;
+    uint16_t count = g35->get_light_count();
+    string_length_[string_count_] = count;
     strings_[string_count_] = g35;
+    light_count_ += count;
     string_count_++;
-    light_count_ += light_count;
 }
 
 uint16_t MEOG35StringGroup::get_light_count()
@@ -34,12 +34,15 @@ uint16_t MEOG35StringGroup::get_light_count()
 void MEOG35StringGroup::set_color(uint16_t bulb, uint8_t intensity, color_t color)
 {
     uint8_t string = 0;
-    while (bulb >= string_offsets_[string] && string < string_count_)
-        bulb -= string_offsets_[string++];
+    uint16_t orig = bulb;
+
+    while (bulb >= string_length_[string] && string < string_count_)
+        bulb -= string_length_[string++];
     if (string < string_count_) {
         strings_[string]->set_color(bulb, intensity, color);
     } else {
-        Serial.println("out of bounds");
+        Serial.print(orig);
+        Serial.println(" out of bounds");
     }
 }
 

--- a/MEOG35StringGroup.cpp
+++ b/MEOG35StringGroup.cpp
@@ -10,24 +10,19 @@
 #include <MEOG35StringGroup.h>
 
 MEOG35StringGroup::MEOG35StringGroup()
-    : string_count_(0)
+    : string_count_(0), light_count_(0)
 {
-    light_count_ = 0;
 }
 
 void MEOG35StringGroup::AddString(MEOG35* g35)
 {
     if (string_count_ == MAX_STRINGS)
-    {
         return;
-    }
+
     uint16_t light_count = g35->get_light_count();
-    string_offsets_[string_count_] =
-        string_count_ == 0 ?
-        light_count :
-        string_offsets_[string_count_ - 1] + light_count;
+    string_offsets_[string_count_] = light_count;
     strings_[string_count_] = g35;
-    ++string_count_;
+    string_count_++;
     light_count_ += light_count;
 }
 
@@ -36,23 +31,15 @@ uint16_t MEOG35StringGroup::get_light_count()
     return light_count_;
 }
 
-void MEOG35StringGroup::set_color(uint8_t bulb, uint8_t intensity, color_t color)
+void MEOG35StringGroup::set_color(uint16_t bulb, uint8_t intensity, color_t color)
 {
     uint8_t string = 0;
     while (bulb >= string_offsets_[string] && string < string_count_)
-    {
         bulb -= string_offsets_[string++];
-    }
-    if (string < string_count_)
-    {
+    if (string < string_count_) {
         strings_[string]->set_color(bulb, intensity, color);
-    }
-    else
-    {
-        // A program is misbehaving.
-#if 0
+    } else {
         Serial.println("out of bounds");
-#endif
     }
 }
 
@@ -62,9 +49,4 @@ void MEOG35StringGroup::broadcast_intensity(uint8_t intensity)
     {
         strings_[i]->broadcast_intensity(intensity);
     }
-}
-
-uint8_t MEOG35StringGroup::get_broadcast_bulb()
-{
-    return 0;  // In this implementation, shouldn't ever be called.
 }

--- a/MEOG35StringGroup.h
+++ b/MEOG35StringGroup.h
@@ -35,5 +35,5 @@ private:
     uint16_t light_count_;
     uint8_t string_count_;
     MEOG35* strings_[MAX_STRINGS];
-    uint16_t string_offsets_[MAX_STRINGS];
+    uint16_t string_length_[MAX_STRINGS];
 };

--- a/MEOG35StringGroup.h
+++ b/MEOG35StringGroup.h
@@ -7,8 +7,7 @@
   README for complete attributions.
 */
 
-#ifndef INCLUDE_MEOG35_STRING_GROUP_H
-#define INCLUDE_MEOG35_STRING_GROUP_H
+#pragma once
 
 #include <MEOG35.h>
 
@@ -25,20 +24,16 @@ public:
 
     void AddString(MEOG35* g35);
 
-    virtual uint16_t get_light_count();
+    uint16_t get_light_count();
 
-    virtual void set_color(uint8_t bulb, uint8_t intensity, color_t color);
-    virtual void broadcast_intensity(uint8_t intensity);
-
-protected:
-    virtual uint8_t get_broadcast_bulb();
+    void set_color(uint16_t bulb, uint8_t intensity, color_t color);
+    void broadcast_intensity(uint8_t intensity);
 
 private:
     enum { MAX_STRINGS = 16 };
 
+    uint16_t light_count_;
     uint8_t string_count_;
     MEOG35* strings_[MAX_STRINGS];
     uint16_t string_offsets_[MAX_STRINGS];
 };
-
-#endif  // INCLUDE_MEOG35_STRING_GROUP_H

--- a/MEOPrograms.cpp
+++ b/MEOPrograms.cpp
@@ -21,6 +21,8 @@ MEOLightProgram* MEOProgramGroup::CreateProgram(MEOG35& lights,
     }
     else
     {
+        Serial.print("Running: ");
+        Serial.println(program_index % ProgramCount);
         switch (program_index % ProgramCount)
         {
         case 0:

--- a/MEORainbow.cpp
+++ b/MEORainbow.cpp
@@ -19,7 +19,7 @@ MEORainbow::MEORainbow(MEOG35& g35, uint8_t pattern) : MEOLightProgram(g35, patt
 
 uint32_t MEORainbow::Do()
 {
-    bool fourtyEight;
+    int step_count;
 	bool toggle;
 	toggle = true;
     for (int i=0; i < light_count_; i++)
@@ -27,39 +27,39 @@ uint32_t MEORainbow::Do()
         switch (pattern_ % 12)
         {
         case 0:
-            fourtyEight = false;
+            step_count = 32;
             g35_.fill_color(i, 1, MEOG35::MAX_INTENSITY, MEORainbow::LineRG((i + step_) % 32));
             break;
         case 1:
-            fourtyEight = false;
+            step_count = 32;
             g35_.fill_color(i, 1, MEOG35::MAX_INTENSITY, MEORainbow::LineGB((i + step_) % 32));
             break;
         case 2:
-            fourtyEight = false;
+            step_count = 32;
             g35_.fill_color(i, 1, MEOG35::MAX_INTENSITY, MEORainbow::LineBR((i + step_) % 32));
             break;
         case 3:
-            fourtyEight = true;
+            step_count = 48;
             g35_.fill_color(i, 1, MEOG35::MAX_INTENSITY, MEORainbow::Wheel((i + step_) % 48));
             break;
         case 4: //spread across all lights (the more lights, the more noticable)
-            fourtyEight = false;
+            step_count = 32;
             g35_.fill_color(i, 1, MEOG35::MAX_INTENSITY, MEORainbow::LineRG(((i * 32 / light_count_) + step_) % 32));
             break;
         case 5:
-            fourtyEight = false;
+            step_count = 32;
             g35_.fill_color(i, 1, MEOG35::MAX_INTENSITY, MEORainbow::LineGB(((i * 32 / light_count_) + step_) % 32));
             break;
         case 6:
-            fourtyEight = false;
+            step_count = 32;
             g35_.fill_color(i, 1, MEOG35::MAX_INTENSITY, MEORainbow::LineBR(((i * 32 / light_count_) + step_) % 32));
             break;
         case 7:
-            fourtyEight = true;
+            step_count = 48;
             g35_.fill_color(i, 1, MEOG35::MAX_INTENSITY, MEORainbow::Wheel(((i * 48 / light_count_) + step_) % 48));
             break;
         case 8: //interlaced
-            fourtyEight = false;
+            step_count = 32;
             if (toggle)
 			{
 				g35_.fill_color(i, 1, MEOG35::MAX_INTENSITY, MEORainbow::LineRG((i + 16 + step_) % 32));
@@ -71,7 +71,7 @@ uint32_t MEORainbow::Do()
 			}
             break;
         case 9:
-            fourtyEight = false;
+            step_count = 48;
 		    if (toggle)
 			{
 				g35_.fill_color(i, 1, MEOG35::MAX_INTENSITY, MEORainbow::LineGB((i + 16 + step_) % 32));
@@ -83,7 +83,7 @@ uint32_t MEORainbow::Do()
 			}
             break;
         case 10:
-            fourtyEight = false;
+            step_count = 32;
             if (toggle)
 			{
 				g35_.fill_color(i, 1, MEOG35::MAX_INTENSITY, MEORainbow::LineBR((i + 16 + step_) % 32));
@@ -95,7 +95,7 @@ uint32_t MEORainbow::Do()
 			}
             break;
         case 11:
-            fourtyEight = true;
+            step_count = 48;
             if (toggle)
 			{
 				g35_.fill_color(i, 1, MEOG35::MAX_INTENSITY, MEORainbow::Wheel((i + 24 + step_) % 48));
@@ -111,11 +111,7 @@ uint32_t MEORainbow::Do()
 
     //reset at end of wheel or line
     step_++;
-    if (((step_ == 48) && fourtyEight) || ((step_ == 32) && !fourtyEight))
-    {
-        step_ = 0;
-    }
-
+    step_ %= step_count;
     delay(wait_);
 
     return bulb_frame_;

--- a/MEORandomStrobe.cpp
+++ b/MEORandomStrobe.cpp
@@ -119,45 +119,23 @@ uint32_t MEORandomStrobe::Do()
     }
 
 
-    ////// This commented out code works, but ideally needs to be outside this class and passed in, because as is the random sequence changes so it's no longer non-repeating
-    ////// I've no idea how to do that, so I'm replacing with pre-generated random arrays
-    ////// and a choice between 50 / 100 bulbs
-    //int myBulbs[light_count_];
-    //int myBulb;
-    //myBulb = 0;
-    //// Initialise myBulbs[] to an ordered range - i.e. myBulbs[0] = 0, myBulbs[1] = 1 etc...
-    //for (int range = 0; range < light_count_; range++)
-    //{
-    //	myBulbs[range] = range;
-    //}
-    //// Random shuffle (note this will always be the same - maybe can re-seed with last number of shuffle?)
-    //// so, myBulbs[0]=38, myBulbs[1]=13.. etc.. for example
-    //for (int shuffle = 0; shuffle < light_count_ - 1; shuffle++)
-    //{
-    //	int myrand = shuffle + (rand() % (light_count_ - shuffle));
-    //	int save = myBulbs[shuffle];
-    //	myBulbs[shuffle] = myBulbs[myrand];
-    //	myBulbs[myrand] = save;
-    //}
-    //srand(myBulbs[0]); //re-seed for next time
-    ////// <<<
-
-    ///// Replacement pre-defined random sequence of bulbs - comment this out, if uncommenting above
-    // If you have different amounts of bulbs, you'll have to create your own non-repeating random sequences.
-    int myBulbs050[100]= {3, 15, 49, 0, 41, 26, 5, 48, 29, 46, 34, 24, 18, 43, 28, 2, 9, 44, 39, 19, 16, 35, 42, 36, 38, 37, 20, 14, 32, 10, 47, 11, 8, 31, 13, 25, 7, 22, 6, 30, 23, 4, 12, 17, 33, 27, 40, 45, 1, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    int myBulbs100[100]= {85, 53, 88, 71, 6, 32, 91, 79, 15, 62, 80, 7, 28, 66, 27, 16, 23, 19, 54, 95, 0, 47, 40, 44, 2, 36, 31, 51, 48, 38, 87, 11, 70, 33, 56, 34, 92, 30, 5, 1, 78, 86, 84, 98, 12, 69, 77, 43, 97, 8, 94, 58, 55, 74, 4, 82, 99, 72, 20, 63, 29, 60, 89, 93, 45, 75, 13, 83, 67, 25, 21, 42, 52, 9, 49, 17, 41, 37, 50, 81, 96, 39, 46, 14, 35, 18, 76, 73, 24, 64, 10, 61, 3, 65, 57, 68, 26, 22, 59, 90};
-    int myBulbs[100];
-    //int myBulb;
-    if (light_count_ == 50)
+    int myBulbs[light_count_];
+    int myBulb;
+    myBulb = 0;
+    // Initialise myBulbs[] to an ordered range - i.e. myBulbs[0] = 0, myBulbs[1] = 1 etc...
+    for (int range = 0; range < light_count_; range++)
     {
-        memcpy(myBulbs, myBulbs050, sizeof(myBulbs));
+    	myBulbs[range] = range;
     }
-    else     //assume 100 bulbs
+    // Random shuffle (note this will always be the same - maybe can re-seed with last number of shuffle?)
+    // so, myBulbs[0]=38, myBulbs[1]=13.. etc.. for example
+    for (int shuffle = 0; shuffle < light_count_ - 1; shuffle++)
     {
-        memcpy(myBulbs, myBulbs100, sizeof(myBulbs));
+        int myrand = shuffle + (rand() % (light_count_ - shuffle));
+        int save = myBulbs[shuffle];
+        myBulbs[shuffle] = myBulbs[myrand];
+        myBulbs[myrand] = save;
     }
-    ////// <<<
-
 
     // pre-fill with background colour if flag set, and first step in
     if (preFill_)

--- a/MEOSimplexNoise.cpp
+++ b/MEOSimplexNoise.cpp
@@ -18,7 +18,10 @@ MEOSimplexNoise::MEOSimplexNoise(MEOG35& g35, uint8_t pattern) : MEOLightProgram
 {
 }
 
+#ifndef PI
 #define PI 3.14159265
+#endif
+
 #define onethird 0.333333333
 #define onesixth 0.166666667
 #define numSpacing 18

--- a/MEOSineWave.cpp
+++ b/MEOSineWave.cpp
@@ -17,7 +17,9 @@ MEOSineWave::MEOSineWave(MEOG35& g35, uint8_t pattern) : MEOLightProgram(g35, pa
 {
 }
 
+#ifndef PI
 #define PI 3.14159265
+#endif
 
 uint32_t MEOSineWave::Do()
 {

--- a/examples/MEOXmas/MEOXmas.ino
+++ b/examples/MEOXmas/MEOXmas.ino
@@ -5,16 +5,16 @@
    subject to the BSD license as described in the accompanying LICENSE file.
 
 By Mike Tsao <github.com/sowbug>. See README for complete attributions. */
- 
+
 // and Mark Ortiz
- 
+
 //Includes multiple button handling by ladyada: http://www.adafruit.com/blog/2009/10/20/example-code-for-multi-button-checker-with-debouncing/
- 
+
 #include <MEOG35String.h>
 #include <MEOG35StringGroup.h>
 #include <MEOProgramRunner.h>
 #include <MEOPrograms.h>
- 
+
 //Buttons initialisation
 //if you want, you can even run the button checker in the background, which can make for a very easy interface. Remember that you’ll need to clear “just pressed”, etc. after checking or it will be “stuck” on
 #define DEBOUNCE 10  // button debouncer, how many ms to debounce, 5+ ms is usually plenty
@@ -24,64 +24,64 @@ byte buttons[] = {54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64}; // the analog A0-
 #define NUMBUTTONS sizeof(buttons)
 // we will track if a button is just pressed, just released, or 'currently pressed'
 volatile byte pressed[NUMBUTTONS], justpressed[NUMBUTTONS], justreleased[NUMBUTTONS];
- 
+
 //timer
 #define PROG_DUR_LONG 86400  //24 hours
 #define PROG_DUR_SHORT 120  //2 minutes
- 
+
 //Lights initialisation
 MEOG35String lights_1(13, 50, 50, 0, false);
 //MEOG35String lights_2(12, 50);
- 
+
 const int PROGRAM_COUNT = MEOProgramGroup::ProgramCount;
- 
+
 MEOProgramGroup programs;
 MEOG35StringGroup string_group;
- 
+
 bool lightsOn = true;
 //bool firstTime = true;
- 
+
 MEOLightProgram* CreateProgram(uint8_t program_index, uint8_t pattern)
 {
 	return programs.CreateProgram(string_group, program_index, pattern);
 }
- 
+
 // How long each program should run.
-uint16_t programDuration = PROG_DUR_SHORT; //set for short first, as random is first
- 
+long programDuration = PROG_DUR_SHORT; //set for short first, as random is first
+
 MEOProgramRunner runner(CreateProgram, PROGRAM_COUNT, programDuration);
- 
+
 void setup()
 {
 	//Lights
 	delay(50);
-	 
+
 	lights_1.enumerate();
 	//lights_2.enumerate();
-	 
+
 	string_group.AddString(&lights_1);
 	//string_group.AddString(&lights_2);
-	 
+
 	//Buttons
 	byte i;
-	 
+
 	// Make input & enable pull-up resistors on switch pins
 	for (i=0; i< NUMBUTTONS; i++)
 	{
 		pinMode(buttons[i], INPUT);
 		digitalWrite(buttons[i], HIGH);
 	}
-	 
+
 	// Run timer2 interrupt every 15 ms
 	TCCR2A = 0;
 	TCCR2B = 1<<CS22 | 1<<CS21 | 1<<CS20;
-	 
+
 	//Timer2 Overflow Interrupt Enable
 	TIMSK2 |= 1<<TOIE2;
 
 	randomSeed(analogRead(0));
 }
- 
+
 void loop()
 {
 	//Lights
@@ -97,15 +97,15 @@ void loop()
 	//} else {
 		runner.loop();
 	//}
-	 
-	 
+
+
 	//Buttons
 	for (byte myButton = 0; myButton < NUMBUTTONS; myButton++)
 	{
 		if (justpressed[myButton])
 		{
 			justpressed[myButton] = 0;
-			 
+
 			switch (myButton)
 			{
 				case 0: //program Up
@@ -153,35 +153,35 @@ void loop()
 		}
 	}
 }
- 
+
 //Debounce buttons - nothing to do with lights...
 SIGNAL(TIMER2_OVF_vect)
 {
 	check_switches();
 }
- 
+
 void check_switches()
 {
 	static byte previousstate[NUMBUTTONS];
 	static byte currentstate[NUMBUTTONS];
 	static long lasttime;
 	byte index;
-	 
+
 	if (millis() < lasttime)
 	{
 		// we wrapped around, lets just try again
 		lasttime = millis();
 	}
-	 
+
 	if ((lasttime + DEBOUNCE) > millis())
 	{
 		// not enough time has passed to debounce
 		return;
 	}
-	 
+
 	// ok we have waited DEBOUNCE milliseconds, lets reset the timer
 	lasttime = millis();
-	 
+
 	for (index = 0; index < NUMBUTTONS; index++)
 	{
 		currentstate[index] = digitalRead(buttons[index]);   // read the button
@@ -202,4 +202,4 @@ void check_switches()
 		previousstate[index] = currentstate[index];   // keep a running tally of the buttons
 	}
 }
- 
+


### PR DESCRIPTION
This fixes some issues with the code, namely the multiple definitions of PI, and using uint8_t as an index into a string group which limits the count to 256 bulbs.  Also, this moves the need for a broadcast bulb into the specific implementation, rather than the common base class as only physical strings have a broadcast bulb.

There are lots of other code cleanup changes, and bug fixes which will cause the random strobe code to work with more than 100 bulbs(basically re-enabling most of the random runtime generation code) and an actual bug fix for StringGroup::AddString().
